### PR TITLE
Update OWNER files to include all team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,4 +2,3 @@
 
 approvers:
   - core-ack-team
-  - service-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,15 @@
 aliases:
   core-ack-team:
     - a-hilaly
-    - RedbackThomson
-    - jljaco
-  # TODO: Add your team members' GitHub aliases to the team alias
-  service-team: []
+    - jlbutler
+    - michaelhtm
+    - rushmash91
+    - knottnt
+  # emeritus-core-ack-team:
+  #   - TiberiuGC
+  #   - jaypipes
+  #   - jljaco
+  #   - mhausenblas
+  #   - RedbackThomson
+  #   - vijtrip2
+  #   - ivelichkovich


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Remove service_team alias
- Move old team members to emeritus comment
- Add jlbutler, michaelhtm, rushmash91, and knottnt to core-team

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
